### PR TITLE
Implemented simple controller.

### DIFF
--- a/include/controller/controller.h
+++ b/include/controller/controller.h
@@ -1,0 +1,38 @@
+#ifndef CONTROLLER_H
+#define CONTROLLER_H
+
+#include <unordered_map>
+#include <typeinfo>
+#include <typeindex>
+
+class ControllerStrategy;
+
+#include "controller/event_queue.hpp"
+
+
+class Controller
+{
+private:
+    EventQueue* const event_queue;
+    std::unordered_map<std::type_index, ControllerStrategy*> strategyMap;
+
+public:
+    Controller(EventQueue* const);
+    void handle_events();
+};
+
+
+class ControllerStrategy
+{
+public:
+    virtual void react(Event* event);
+    ControllerStrategy();
+};
+
+
+class StringStrategy: public ControllerStrategy
+{
+public:
+    virtual void react(Event* event);
+};
+#endif

--- a/include/controller/event_queue.hpp
+++ b/include/controller/event_queue.hpp
@@ -1,0 +1,43 @@
+#ifndef EVENT_QUEUE_H
+#define EVENT_QUEUE_H
+
+#include <queue>
+#include <mutex>
+#include <condition_variable>
+
+#include "events.h"
+
+
+template<typename T>
+class BlockingQueue
+{
+private:
+    std::queue<T> queue;
+    std::mutex mutex;
+    std::condition_variable condition;
+
+public:
+    void push(T const &item)
+    {
+        std::unique_lock<std::mutex> mlock(mutex);
+        queue.push(item);
+        mlock.unlock();
+        condition.notify_one();
+    }
+
+    T pop()
+    {
+        std::unique_lock<std::mutex> mlock(mutex);
+        while (queue.empty())
+        {
+            condition.wait(mlock);
+        }
+        auto item = queue.front();
+        queue.pop();
+        return item;
+    }
+};
+
+typedef BlockingQueue<Event*> EventQueue;
+
+#endif

--- a/include/controller/events.h
+++ b/include/controller/events.h
@@ -1,0 +1,23 @@
+#include <string>
+
+#ifndef EVENTS_H
+#define EVENTS_H
+
+using namespace std;
+class Event
+{
+public:
+    virtual ~Event();
+};
+
+class StringEvent: public Event
+{
+private:
+    string message;
+public:
+    virtual ~StringEvent();
+    virtual string getMessage();
+        StringEvent(string message);
+};
+
+#endif

--- a/src/controller/controller.cpp
+++ b/src/controller/controller.cpp
@@ -1,0 +1,39 @@
+#include <typeindex>
+#include <iostream>
+#include <utility>
+
+#include "controller/controller.h"
+
+
+Controller::Controller(EventQueue* const event_queue) : event_queue(event_queue)
+{
+    this->strategyMap.insert(std::make_pair<std::type_index, StringStrategy*>
+            (std::type_index(typeid(StringEvent)), new StringStrategy()));
+}
+
+void Controller::handle_events()
+{
+    while(true)
+    {
+        Event* event = event_queue->pop();
+        ControllerStrategy* strategy =
+            strategyMap[std::type_index(typeid(*event))];
+        strategy->react(event);
+
+    }
+}
+
+void StringStrategy::react(Event* event)
+{
+    StringEvent* stringEven = dynamic_cast<StringEvent*>(event);
+}
+
+ControllerStrategy::ControllerStrategy()
+{
+
+}
+
+void ControllerStrategy::react(Event* event)
+{
+
+}

--- a/src/controller/events.cpp
+++ b/src/controller/events.cpp
@@ -1,0 +1,24 @@
+#include <string>
+
+#include "controller/events.h"
+
+
+StringEvent::StringEvent(string message)
+{
+    this->message = message;
+}
+
+string StringEvent::getMessage()
+{
+    return message;
+}
+
+Event::~Event()
+{
+
+}
+
+StringEvent::~StringEvent()
+{
+
+}


### PR DESCRIPTION
Implementacja controllera. Wystarczy uruchomić jako wątek i uruchomić mu handle_events(). Nowe typy eventów wrzucamy do events, a strategie ich obslugi piszemy w controllerze.
